### PR TITLE
adding MacOSX support, but linked errror

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(Boost_USE_STATIC_RUNTIME    ON)
 
 find_package( Boost 1.50 REQUIRED COMPONENTS thread filesystem)
 find_package( ffmpeg REQUIRED)
+find_package( X11 REQUIRED)
 
 add_definitions(-D__STDC_CONSTANT_MACROS)
 
@@ -19,6 +20,7 @@ add_definitions(-D__STDC_CONSTANT_MACROS)
 include_directories(${Boost_INCLUDE_DIRS})
 include_directories(${PROJECT_SOURCE_DIR})
 include_directories(${FFMPEG_INCLUDE_DIR})
+include_directories(${X11_INCLUDE_DIR})
 include_directories(libav/)
 include_directories(source/)
 include_directories(audio/)

--- a/libav/avplay.c
+++ b/libav/avplay.c
@@ -30,7 +30,13 @@ enum bool_type
 #define SEEKING_FLAG			-1
 #define NOSEEKING_FLAG			0
 
-#ifndef _MSC_VER
+#ifdef __APPLE__
+#include <mach/clock.h>
+#include <mach/mach.h>
+#define CLOCK_MONOTONIC SYSTEM_CLOCK
+#endif
+
+#if (defined __linux) || (defined __APPLE__)
 #include <unistd.h>
 #include <sys/time.h>
 #include <time.h>
@@ -55,8 +61,9 @@ int64_t av_gettime()
 	clock_gettime(CLOCK_MONOTONIC,&cltime);
 	return cltime.tv_sec * 1000000 + cltime.tv_nsec / 1000;
 }
+#endif
 
-#else
+#ifdef _MSC_VER
 #define av_gettime() (timeGetTime() * 1000.0f)
 #endif
 


### PR DESCRIPTION
Any help? errors:

``` bash
mbp:fuck mic$ make
[  1%] Built target av
[  3%] Built target avvideo
[  5%] Built target avaudio
[  9%] Built target avsource
[ 94%] Built target torrent-rasterbar
[ 97%] Built target libky
[ 98%] Linking CXX executable ../avplayer
clang: warning: argument unused during compilation: '-pthread'
Undefined symbols for architecture x86_64:
  "std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::empty() const", referenced from:
      libtorrent::torrent::replace_trackers(std::__1::vector<libtorrent::announce_entry, std::__1::allocator<libtorrent::announce_entry> > const&) in libtorrent-rasterbar.a(torrent.cpp.o)
  "_clock_gettime", referenced from:
      _av_gettime in libav.a(avplay.c.o)
  "_clock_nanosleep", referenced from:
      _Sleep in libav.a(avplay.c.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [avplayer] Error 1
make[1]: *** [linux/CMakeFiles/avplayer.dir/all] Error 2
make: *** [all] Error 2
```
